### PR TITLE
Pin Scipy to below v1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - numpy >=1.9.1
     - progressbar2
     - python-dateutil
-    - scipy >=0.16.0
+    - scipy >=0.16.0,<1.0.0
     - six >=1.10.0
     - xarray >=0.5.1
 


### PR DESCRIPTION
Currently, scipy packages are marked as broken in the conda-forge channel: <https://anaconda.org/conda-forge/scipy/files> This results in an incompatible scipy package from the Anaconda defaults being installed.  We pin to latest below v1.0 to make sure this does not happen.